### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,9 +34,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user_id != current_user.id
-      render :show
-    end
+    render :show if @item.user_id != current_user.id
     @item.destroy
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :item_find, only: [:show, :edit, :update]
+  before_action :item_find, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.order('created_at DESC')
   end
@@ -31,6 +31,14 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    if @item.user_id != current_user.id
+      render :show
+    end
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,8 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.price %>
+      ¥
+        <%=  @item.price %>
       </span>
       <span class="item-postage">
         <%= @item.shipping_burden.name %>
@@ -27,7 +28,7 @@
       <% if @item.user.id == current_user.id %>
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
       <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
# WHAT
削除機能の実装
showページから商品を出品したユーザーのみdestroyアクションで商品を削除できる。
# WHY
削除機能が無いと間違った出品を取り消せないため

商品のユーザーによる削除
https://gyazo.com/a2f3b2b4321ab6b70457f88a28717a95
未ログインユーザーには削除ボタンが出ていません。
https://gyazo.com/6519a0b28efbef4b8687d7ba23672c86
出品主でないユーザーにも削除ボタンは出ていません。
https://gyazo.com/29f95f9415669a1f1384ad559b327d5a